### PR TITLE
Constrain watchdog dependency to <1.0.0. 

### DIFF
--- a/.ci_support/migrations/hdf51106.yaml
+++ b/.ci_support/migrations/hdf51106.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-hdf5:
-- 1.10.6
-migrator_ts: 1587001869.689825

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 34c002779a9d8ad94d1720142e74da9795396727b700a2a2db78e2194a34f719
 
 build:
-  number: 0
+  number: 1
   # there are dependency conflicts for Python 2 on Windows
   skip: true  # [win and py2k]
   run_exports:
@@ -38,7 +38,7 @@ requirements:
     - python-dateutil
     - pytz
     - six
-    - watchdog
+    - watchdog <1.0.0
 
 test:
   requires:


### PR DESCRIPTION
This version of digital_rf is incompatible with changes introduced in
watchdog 1.0.0.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
